### PR TITLE
adjust reference year to current year

### DIFF
--- a/.github/workflows/check-ipc.yaml
+++ b/.github/workflows/check-ipc.yaml
@@ -1,0 +1,29 @@
+name: Check HAPI for IPC Updates
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  run-script:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run script
+      run: python main.py
+      env:
+        DSCI_AZ_BLOB_DEV_SAS_WRITE: ${{ secrets.DSCI_AZ_BLOB_DEV_SAS_WRITE }}
+        HAPI_APP_IDENTIFIER: ${{ secrets.HAPI_APP_IDENTIFIER }}

--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ from dash import html, Output, Input, callback, State, dcc
 import dash
 import dash_ag_grid as dag
 import ocha_stratus as stratus
-from datetime import datetime
+from datetime import datetime, timedelta
 
 
 NAVBAR_HEIGHT = 60
@@ -244,10 +244,10 @@ def download_hunger_period_reference(n_clicks):
     Input("severity-dropdown", "value"),
 )
 def load_data(severity):
-    now = datetime.now()
-    now_formatted = now.strftime("%Y-%m-%d")
+    yesterday = datetime.now() - timedelta(days=1)
+    yesterday_formatted = yesterday.strftime("%Y-%m-%d")
     df = stratus.load_csv_from_blob(
-        f"ds-ufe-food-security/processed/ipc_updates/annualized_ipc_summary_{severity}_{now_formatted}.csv"
+        f"ds-ufe-food-security/processed/ipc_updates/annualized_ipc_summary_{severity}_{yesterday_formatted}.csv"
     )
 
     column_defs = [{"field": i} for i in df.columns]

--- a/app.py
+++ b/app.py
@@ -35,12 +35,36 @@ def disclaimer_modal():
                         [hannah.ker@un.org](mailto:hannah.ker@un.org) and [giulia.martini@un.org](mailto:giulia.martini@un.org).
                         """
                     ),
+                    dcc.Markdown(
+                        """
+                        All statistics are compiled based on an estimated Peak Hunger Period (PHP) for each country, which
+                        is defined to enable meaningful year-on-year comparisons. This PHP is set based on the period within
+                        the past year that has the greatest percentage of the population in Phase 3+. **Users should be aware**
+                        that this simplified approach may not accurately capture more complex cases, such as dual lean seasons or
+                        subnational differentiation. Food insecurity driven by irregular factors such as conflict may also skew these
+                        outputs from what might be expected. Refer to the
+                        [methodology](https://docs.google.com/document/d/15o6f5yPIl3p3sj7NNw2MoHg6f7DHzwtCPfKRlfU2PJE/edit?tab=t.0) for more details.
+
+                        """,
+                        style={"marginTop": "10px"},
+                    ),
+                    dcc.Markdown(
+                        """
+                        The results displayed in this app are from an **entirely automated analysis**. Users may wish to refer to the [IPC reports](https://www.ipcinfo.org/)
+                        directly in cases where local knowledge overrides the analytically-estimated Peak Hunger Periods.
+                        """,
+                        style={"marginTop": "10px"},
+                    ),
                 ]
+            ),
+            dbc.ModalFooter(
+                dbc.Button("I understand", id="close", className="ms-auto", n_clicks=0)
             ),
         ],
         id="modal",
         is_open=True,
         centered=True,
+        size="lg",
     )
 
 
@@ -103,7 +127,7 @@ def sidebar_controls():
             html.Div(
                 [
                     dbc.Button(
-                        "Download Hunger Periods",
+                        "Download Reference Hunger Periods",
                         color="secondary",
                         id="reference-download-button",
                     ),
@@ -206,6 +230,17 @@ layout = [
 
 
 app.layout = html.Div(layout)
+
+
+@app.callback(
+    Output("modal", "is_open"),
+    Input("close", "n_clicks"),
+    State("modal", "is_open"),
+)
+def toggle_modal(n1, is_open):
+    if n1:
+        return not is_open
+    return is_open
 
 
 @callback(

--- a/app.py
+++ b/app.py
@@ -219,7 +219,7 @@ def export_data_as_csv(n_clicks, severity):
     now_formatted = now.strftime("%Y-%m-%d")
     if n_clicks:
         return True, {
-            "fileName": f"annualized_ipc_conditions_{severity}_{now_formatted}.csv"
+            "fileName": f"annualized_ipc_conditions_{severity}_{now_formatted}_TEST.csv"
         }
     return False, {}
 

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     ref_severity = "3+"
 
     # Get the raw data and find the peak hunger periods from the reference year
-    logger.info(f"Identifying peak hunger periods based on {ref_year}")
+    logger.info("Identifying peak hunger periods...")
     df = ipc.get_all_ipc()
     df = ipc.combine_4_plus(df)
     df_peak = ipc.identify_peak_hunger_period(df, ref_year, ref_severity)

--- a/main.py
+++ b/main.py
@@ -7,24 +7,22 @@ from src.datasources import ipc
 from src.config import LOG_LEVEL, PROJECT_PREFIX
 from src.utils import date_utils, format_utils
 
-# References for identifying the peak hunger period
-REF_YEAR = 2024
-REF_SEVERITY = "3+"
-
 logger = logging.getLogger(__name__)
 coloredlogs.install(level=LOG_LEVEL, logger=logger)
 
-years = [REF_YEAR, REF_YEAR - 1, REF_YEAR - 2]
 
 if __name__ == "__main__":
     now = datetime.now()
     now_formatted = now.strftime("%Y-%m-%d")
+    ref_year = now.year
+    years = [ref_year, ref_year - 1, ref_year - 2]
+    ref_severity = "3+"
 
     # Get the raw data and find the peak hunger periods from the reference year
-    logger.info(f"Identifying peak hunger periods based on {REF_YEAR}")
+    logger.info(f"Identifying peak hunger periods based on {ref_year}")
     df = ipc.get_all_ipc()
     df = ipc.combine_4_plus(df)
-    df_peak = ipc.identify_peak_hunger_period(df, REF_YEAR, REF_SEVERITY)
+    df_peak = ipc.identify_peak_hunger_period(df, ref_year, ref_severity)
 
     # Check the overlap in reference periods
     df_periods = stratus.load_csv_from_blob(
@@ -44,7 +42,7 @@ if __name__ == "__main__":
     for severity in ["3", "3+", "4", "4+", "5"]:
         df_summary = df_peak
         df_summary["phase"] = severity
-        fname = f"annualized_ipc_summary_{REF_YEAR}_{severity}_{now_formatted}.csv"
+        fname = f"annualized_ipc_summary_{severity}_{now_formatted}.csv"
         for year in years:
             df_matched = ipc.match_peak_hunger_period(df, df_peak, year, severity)
             df_summary = df_summary.merge(df_matched, how="left")

--- a/src/utils/date_utils.py
+++ b/src/utils/date_utils.py
@@ -45,7 +45,8 @@ def apply_overlap(df, df_periods, target_period_column, output_column):
     return df_summary.drop(columns=["reference_period_months"])
 
 
-def get_ref_period(row, ref_year):
+def get_ref_period(row):
+    ref_year = row["reference_year"]
     # Account for the Jan - Dec cross
     from_year = ref_year - (1 if row["From"].month > row["To"].month else 0)
     from_date = pd.Timestamp(

--- a/src/utils/format_utils.py
+++ b/src/utils/format_utils.py
@@ -14,7 +14,7 @@ def clean_columns(df_summary):
     period_cols = [col for col in df_summary.columns if "report_period" in col]
 
     final_cols = (
-        ["location_code", "reference_year", "phase", "reference_period"]
+        ["location_code", "phase", "reference_period"]
         + change_cols
         + percentage_cols
         + number_cols


### PR DESCRIPTION
Adds a GitHub action to update data daily, and removed the date dropdown from the UI. I think we can just automatically display the data from the previous day's update. 

New files are added into the `dev` Azure blob every day to maintain versioning from past days. I'm not sure how important this is tbh... I think once we've stabilized things more, we can just overwrite a single file each day. 

Have also updated the filtering on the reference period to reference all data from the last year (instead of fixing a specific year).